### PR TITLE
Re-order export conditions

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,12 +24,12 @@
 	"types": "./dist/index.d.ts",
 	"exports": {
 		".": {
-			"default": "./dist/index.js",
-			"types": "./dist/index.d.ts"
+			"types": "./dist/index.d.ts",
+			"default": "./dist/index.js"
 		},
 		"./sitemap": {
-			"default": "./dist/sitemap.js",
-			"types": "./dist/sitemap.d.ts"
+			"types": "./dist/sitemap.d.ts",
+			"default": "./dist/sitemap.js"
 		}
 	},
 	"scripts": {


### PR DESCRIPTION
This is going to sound *so* silly, but this issue is preventing me from using this project. Basically, Webpack gets really angry about the order of keys in the `exports` of `package.json`, it insists the `default` **MUST** come last.

Here are some other libraries that have run into this:

- https://github.com/vuetifyjs/vuetify/issues/17436
- https://github.com/pixijs/pixijs/issues/9691
- https://github.com/euberdeveloper/dree/issues/44

I'd love to use the library, but this is stopping me...