### PR TITLE
Render empty tags correctly and escape text for html

### DIFF
--- a/scripts/tag_generator.mts
+++ b/scripts/tag_generator.mts
@@ -26,8 +26,8 @@ function doctypeElement(): Doctype {
 
 		if (isVoid) {
 			elements += `
-function ${tag}Element(attrs: ATTRIBUTE_MAP["${tag}"]): ELEMENT_MAP["${tag}"] {
-  return new VoidBaseHTMLElement("${tag}", attrs);
+function ${tag}Element(attrs?: ATTRIBUTE_MAP["${tag}"]): ELEMENT_MAP["${tag}"] {
+  return new VoidBaseHTMLElement("${tag}", attrs ?? {} as ATTRIBUTE_MAP["${tag}"]);
 }
 
 `.trimStart();

--- a/src/__snapshots__/sitemap.test.ts.snap
+++ b/src/__snapshots__/sitemap.test.ts.snap
@@ -10,21 +10,21 @@ exports[`sitemap > sample works 1`] = `
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>http://www.example.com/catalog?item=12&desc=vacation_hawaii</loc>
+    <loc>http://www.example.com/catalog?item=12&#x26;desc=vacation_hawaii</loc>
     <changefreq>weekly</changefreq>
   </url>
   <url>
-    <loc>http://www.example.com/catalog?item=73&desc=vacation_new_zealand</loc>
+    <loc>http://www.example.com/catalog?item=73&#x26;desc=vacation_new_zealand</loc>
     <lastmod>2004-12-23</lastmod>
     <changefreq>weekly</changefreq>
   </url>
   <url>
-    <loc>http://www.example.com/catalog?item=74&desc=vacation_newfoundland</loc>
+    <loc>http://www.example.com/catalog?item=74&#x26;desc=vacation_newfoundland</loc>
     <lastmod>2004-12-23</lastmod>
     <priority>0.3</priority>
   </url>
   <url>
-    <loc>http://www.example.com/catalog?item=83&desc=vacation_usa</loc>
+    <loc>http://www.example.com/catalog?item=83&#x26;desc=vacation_usa</loc>
     <lastmod>2004-11-23</lastmod>
   </url>
 </urlset>"

--- a/src/html_tags.test.ts
+++ b/src/html_tags.test.ts
@@ -60,9 +60,9 @@ test("it renders empty elements correctly", ({ expect }) => {
 });
 
 test("it renders html-unsafe characters correctly", ({ expect }) => {
-	expect(renderElement(h.div(`'&"><`))).toBe("<div>&#39;&amp;&quot;&gt;&lt;</div>");
-	expect(renderElement(h.div({ class: `'&"><` }))).toBe(`<div class="&#39;&amp;&quot;&gt;&lt;"></div>`);
+	expect(renderElement(h.div(`'&"><`))).toBe("<div>&#x27;&amp;&quot;&gt;&lt;</div>");
+	expect(renderElement(h.div({ class: `'&"><` }))).toBe(`<div class="&#x27;&amp;&quot;&gt;&lt;"></div>`);
 	expect(renderElement(h.div({ class: `'&"><` }, `'&"><`, h.div(`'&"><`), `'&"><`))).toBe(
-		`<div class="&#39;&amp;&quot;&gt;&lt;">&#39;&amp;&quot;&gt;&lt;<div>&#39;&amp;&quot;&gt;&lt;</div>&#39;&amp;&quot;&gt;&lt;</div>`,
+		`<div class="&#x27;&amp;&quot;&gt;&lt;">&#x27;&amp;&quot;&gt;&lt;<div>&#x27;&amp;&quot;&gt;&lt;</div>&#x27;&amp;&quot;&gt;&lt;</div>`,
 	);
 });

--- a/src/html_tags.test.ts
+++ b/src/html_tags.test.ts
@@ -51,3 +51,18 @@ test("it works redux ", ({ expect }) => {
 		],
 	});
 });
+
+test("it renders empty elements correctly", ({ expect }) => {
+	expect(renderElement(h.div())).toBe("<div></div>");
+	expect(renderElement(h.div({ class: "foo" }))).toBe(`<div class="foo"></div>`);
+	expect(renderElement(h.br())).toBe("<br />");
+	expect(renderElement(h.br({ class: "foo" }))).toBe(`<br class="foo" />`);
+});
+
+test("it renders html-unsafe characters correctly", ({ expect }) => {
+	expect(renderElement(h.div(`'&"><`))).toBe("<div>&#39;&amp;&quot;&gt;&lt;</div>");
+	expect(renderElement(h.div({ class: `'&"><` }))).toBe(`<div class="&#39;&amp;&quot;&gt;&lt;"></div>`);
+	expect(renderElement(h.div({ class: `'&"><` }, `'&"><`, h.div(`'&"><`), `'&"><`))).toBe(
+		`<div class="&#39;&amp;&quot;&gt;&lt;">&#39;&amp;&quot;&gt;&lt;<div>&#39;&amp;&quot;&gt;&lt;</div>&#39;&amp;&quot;&gt;&lt;</div>`,
+	);
+});

--- a/src/html_tags.ts
+++ b/src/html_tags.ts
@@ -51,8 +51,8 @@ function addressElement(
     children,
   );
 }
-function areaElement(attrs: ATTRIBUTE_MAP["area"]): ELEMENT_MAP["area"] {
-  return new VoidBaseHTMLElement("area", attrs);
+function areaElement(attrs?: ATTRIBUTE_MAP["area"]): ELEMENT_MAP["area"] {
+  return new VoidBaseHTMLElement("area", attrs ?? {} as ATTRIBUTE_MAP["area"]);
 }
 
 
@@ -107,8 +107,8 @@ function bElement(
     children,
   );
 }
-function baseElement(attrs: ATTRIBUTE_MAP["base"]): ELEMENT_MAP["base"] {
-  return new VoidBaseHTMLElement("base", attrs);
+function baseElement(attrs?: ATTRIBUTE_MAP["base"]): ELEMENT_MAP["base"] {
+  return new VoidBaseHTMLElement("base", attrs ?? {} as ATTRIBUTE_MAP["base"]);
 }
 
 
@@ -163,8 +163,8 @@ function bodyElement(
     children,
   );
 }
-function brElement(attrs: ATTRIBUTE_MAP["br"]): ELEMENT_MAP["br"] {
-  return new VoidBaseHTMLElement("br", attrs);
+function brElement(attrs?: ATTRIBUTE_MAP["br"]): ELEMENT_MAP["br"] {
+  return new VoidBaseHTMLElement("br", attrs ?? {} as ATTRIBUTE_MAP["br"]);
 }
 
 
@@ -232,8 +232,8 @@ function codeElement(
     children,
   );
 }
-function colElement(attrs: ATTRIBUTE_MAP["col"]): ELEMENT_MAP["col"] {
-  return new VoidBaseHTMLElement("col", attrs);
+function colElement(attrs?: ATTRIBUTE_MAP["col"]): ELEMENT_MAP["col"] {
+  return new VoidBaseHTMLElement("col", attrs ?? {} as ATTRIBUTE_MAP["col"]);
 }
 
 
@@ -392,8 +392,8 @@ function emElement(
     children,
   );
 }
-function embedElement(attrs: ATTRIBUTE_MAP["embed"]): ELEMENT_MAP["embed"] {
-  return new VoidBaseHTMLElement("embed", attrs);
+function embedElement(attrs?: ATTRIBUTE_MAP["embed"]): ELEMENT_MAP["embed"] {
+  return new VoidBaseHTMLElement("embed", attrs ?? {} as ATTRIBUTE_MAP["embed"]);
 }
 
 
@@ -577,8 +577,8 @@ function hgroupElement(
     children,
   );
 }
-function hrElement(attrs: ATTRIBUTE_MAP["hr"]): ELEMENT_MAP["hr"] {
-  return new VoidBaseHTMLElement("hr", attrs);
+function hrElement(attrs?: ATTRIBUTE_MAP["hr"]): ELEMENT_MAP["hr"] {
+  return new VoidBaseHTMLElement("hr", attrs ?? {} as ATTRIBUTE_MAP["hr"]);
 }
 
 
@@ -620,12 +620,12 @@ function iframeElement(
     children,
   );
 }
-function imgElement(attrs: ATTRIBUTE_MAP["img"]): ELEMENT_MAP["img"] {
-  return new VoidBaseHTMLElement("img", attrs);
+function imgElement(attrs?: ATTRIBUTE_MAP["img"]): ELEMENT_MAP["img"] {
+  return new VoidBaseHTMLElement("img", attrs ?? {} as ATTRIBUTE_MAP["img"]);
 }
 
-function inputElement(attrs: ATTRIBUTE_MAP["input"]): ELEMENT_MAP["input"] {
-  return new VoidBaseHTMLElement("input", attrs);
+function inputElement(attrs?: ATTRIBUTE_MAP["input"]): ELEMENT_MAP["input"] {
+  return new VoidBaseHTMLElement("input", attrs ?? {} as ATTRIBUTE_MAP["input"]);
 }
 
 
@@ -693,8 +693,8 @@ function liElement(
     children,
   );
 }
-function linkElement(attrs: ATTRIBUTE_MAP["link"]): ELEMENT_MAP["link"] {
-  return new VoidBaseHTMLElement("link", attrs);
+function linkElement(attrs?: ATTRIBUTE_MAP["link"]): ELEMENT_MAP["link"] {
+  return new VoidBaseHTMLElement("link", attrs ?? {} as ATTRIBUTE_MAP["link"]);
 }
 
 
@@ -761,8 +761,8 @@ function menuElement(
     children,
   );
 }
-function metaElement(attrs: ATTRIBUTE_MAP["meta"]): ELEMENT_MAP["meta"] {
-  return new VoidBaseHTMLElement("meta", attrs);
+function metaElement(attrs?: ATTRIBUTE_MAP["meta"]): ELEMENT_MAP["meta"] {
+  return new VoidBaseHTMLElement("meta", attrs ?? {} as ATTRIBUTE_MAP["meta"]);
 }
 
 
@@ -1089,8 +1089,8 @@ function smallElement(
     children,
   );
 }
-function sourceElement(attrs: ATTRIBUTE_MAP["source"]): ELEMENT_MAP["source"] {
-  return new VoidBaseHTMLElement("source", attrs);
+function sourceElement(attrs?: ATTRIBUTE_MAP["source"]): ELEMENT_MAP["source"] {
+  return new VoidBaseHTMLElement("source", attrs ?? {} as ATTRIBUTE_MAP["source"]);
 }
 
 
@@ -1327,8 +1327,8 @@ function trElement(
     children,
   );
 }
-function trackElement(attrs: ATTRIBUTE_MAP["track"]): ELEMENT_MAP["track"] {
-  return new VoidBaseHTMLElement("track", attrs);
+function trackElement(attrs?: ATTRIBUTE_MAP["track"]): ELEMENT_MAP["track"] {
+  return new VoidBaseHTMLElement("track", attrs ?? {} as ATTRIBUTE_MAP["track"]);
 }
 
 
@@ -1383,8 +1383,8 @@ function videoElement(
     children,
   );
 }
-function wbrElement(attrs: ATTRIBUTE_MAP["wbr"]): ELEMENT_MAP["wbr"] {
-  return new VoidBaseHTMLElement("wbr", attrs);
+function wbrElement(attrs?: ATTRIBUTE_MAP["wbr"]): ELEMENT_MAP["wbr"] {
+  return new VoidBaseHTMLElement("wbr", attrs ?? {} as ATTRIBUTE_MAP["wbr"]);
 }
 
 

--- a/src/pretty_printer.ts
+++ b/src/pretty_printer.ts
@@ -3,20 +3,8 @@ import { isPhrasingTag } from "./content_categories.js";
 import { BaseHTMLElement, Doctype, type HTMLDocument, VoidBaseHTMLElement } from "./html_element.js";
 import { VoidXMLElement, XMLDeclaration, type XMLDocument, XMLElement } from "./xml.js";
 
-const escapeXml = (text: string): string => {
-	return stringifyEntities(text, { escapeOnly: true });
-};
-
-const ESCAPE_HTML = {
-	"&": "&amp;",
-	"<": "&lt;",
-	">": "&gt;",
-	"'": "&#39;",
-	'"': "&quot;",
-} as const;
-
-const escapeHtml = (text: string): string =>
-	text.replaceAll(/[&<>'"]/g, (match) => ESCAPE_HTML[match as keyof typeof ESCAPE_HTML]);
+const escapeXml = (text: string): string => stringifyEntities(text, { escapeOnly: true });
+const escapeHtml = (text: string): string => stringifyEntities(text, { escapeOnly: true, useNamedReferences: true });
 
 const escapeText = (mode: FormatterMode, text: string): string => (mode === "xml" ? escapeXml(text) : escapeHtml(text));
 


### PR DESCRIPTION
I'm not sure why html content wasn't being escaped, but this PR fixes this while allowing all elements to not be passed arguments and still render correctly.

Does this seem fine? XML escaping is a lot more complicated because it's so context-dependent and so I'm steering clear of that in this PR.

```typescript
test("it renders empty elements correctly", ({ expect }) => {
	// This errors out due to h.div() not receiving attrs.
	// If I an empty object as the argument the result is "<div><<div/>"
	expect(renderElement(h.div())).toBe("<div></div>");

	// results in the following: "<div class="foo"><<div class="foo"/>"
	expect(renderElement(h.div({ class: "foo" }))).toBe(`<div class="foo"></div>`);

	// This gives a type error due to missing attrs argument to h.br()
	expect(renderElement(h.br())).toBe("<br />");
	expect(renderElement(h.br({ class: "foo" }))).toBe(`<br class="foo" />`);
});

test("it renders html-unsafe characters correctly", ({ expect }) => {
	// renders: "<div>'&"><</div>"
	expect(renderElement(h.div(`'&"><`))).toBe("<div>&#39;&amp;&quot;&gt;&lt;</div>");

	// renders: "<div class="&#x27;&#x26;&#x22;&#x3E;&#x3C;"><<div class="&#x27;&#x26;&#x22;&#x3E;&#x3C;"/>"
	expect(renderElement(h.div({ class: `'&"><` }))).toBe(`<div class="&#39;&amp;&quot;&gt;&lt;"></div>`);

	// renders: "<div class="&#x27;&#x26;&#x22;&#x3E;&#x3C;">'&"><<div>'&"><</div>'&"><</div>"
	expect(renderElement(h.div({ class: `'&"><` }, `'&"><`, h.div(`'&"><`), `'&"><`))).toBe(
		`<div class="&#39;&amp;&quot;&gt;&lt;">&#39;&amp;&quot;&gt;&lt;<div>&#39;&amp;&quot;&gt;&lt;</div>&#39;&amp;&quot;&gt;&lt;</div>`,
	);
});
```